### PR TITLE
Added Certificate Ripper

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Initial contents and hierarchy inspired by the [Awesome Mac list](https://github
 * [oh-my-fish](https://github.com/oh-my-fish/oh-my-fish) - Like oh-my-zsh, for Fish Shell.
 * [bash-it](https://github.com/Bash-it/bash-it) - Shameless ripoff of oh-my-zsh for Bash.
 * [mycli](https://github.com/dbcli/mycli) - A command line client for MySQL that can do auto-completion and syntax highlighting.
+* [Certificate Ripper](https://github.com/Hakky54/certificate-ripper) - A CLI tool to extract server certificates from a URL.
 
 ## Database
 


### PR DESCRIPTION
Certificate Ripper is a lightweight, easy-to-use CLI tool that allows developers and security engineers to extract and inspect SSL/TLS certificates from remote servers directly from the terminal — no browser or GUI required.

Working with certificates is a common task when debugging HTTPS connectivity issues, verifying certificate chains, or auditing expiry dates across environments. While tools like OpenSSL can do this, they require verbose and hard-to-remember commands. Certificate Ripper offers a simpler, more developer-friendly
experience with support for multiple export formats (PEM, PKCS12, and more)