### PR TITLE
Add shotpaste to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Initial contents and hierarchy inspired by the [Awesome Mac list](https://github
 * [Freeplane](http://freeplane.sourceforge.net/) - Free mind mapping and knowledge management software.
 * [ShellShape](http://gfxmonk.net/shellshape/) - Gnome extension for tiling windows.
 * [KeePassX](https://www.keepassx.org) - A light-weight and open-source password management app.
+* [shotpaste](https://github.com/ebrahim-sameh/shotpaste) - Atomic multi-format clipboard for screenshots: image + file + path on one paste, in any app.
 
 ## File Management
 


### PR DESCRIPTION
Adding [shotpaste](https://github.com/ebrahim-sameh/shotpaste) to the Productivity section.

shotpaste is a small Rust daemon that watches your screenshot folder and writes image bytes + file-drop list + path text to the clipboard atomically — so a single paste does the right thing in any app: image-paste in Slack, file-drop into a JIRA upload zone, path-text in a terminal.

- Free and open source (MIT)
- Desktop application (background daemon, not a server-side tool)
- Works on Linux (Wayland + X11), macOS, and Windows
- Available on crates.io: https://crates.io/crates/shotpaste